### PR TITLE
cancel tests better with control+c and other kill signals

### DIFF
--- a/01sanity_test.go
+++ b/01sanity_test.go
@@ -2,8 +2,6 @@ package main
 
 import (
 	"testing"
-
-	"github.com/erikh/tftest"
 )
 
 func Test00Sanity(t *testing.T) {
@@ -11,7 +9,7 @@ func Test00Sanity(t *testing.T) {
 	// not the first test; someone else added a test that runs before this and
 	// should be scolded. :P
 
-	tf := tftest.New(t)
+	tf := getTFTest(t)
 	tf.Apply("testdata/plans/sanity-test.tf")
 }
 
@@ -19,6 +17,6 @@ func Test01Plugin(t *testing.T) {
 	// this test just tests that the plugin exists and terraform is not mad about
 	// where is. Other places install it, we just want to make sure it'll work.
 
-	tf := tftest.New(t)
+	tf := getTFTest(t)
 	tf.Apply("testdata/plans/plugin-sanity-test.tf")
 }

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ fmt:
 
 test: test-image mktfrc 
 	go build -o .tfdata/registry.terraform.io/hashicorp/zerotier/1.0.0/${OS_ARCH}/${BINARY}
-	go test ${TEST_VERBOSE} ./... ${TEST_COUNT}
+	go test ${TEST_VERBOSE} ./... ${TEST_COUNT} -p 1 # one test at at time
 
 lint: bin/golangci-lint
 	bin/golangci-lint run -v

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/docker/docker v20.10.3+incompatible
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-units v0.4.0 // indirect
-	github.com/erikh/tftest v0.0.0-20210204230340-5267aaa9c572
+	github.com/erikh/tftest v0.0.0-20210209001423-da33e4a905df
 	github.com/fatih/color v1.10.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.4.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -88,6 +88,8 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.m
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/erikh/tftest v0.0.0-20210204230340-5267aaa9c572 h1:WRAysPPLjxVj6qWFc+mNQJFsKtZEBdn3NisCwCphS3M=
 github.com/erikh/tftest v0.0.0-20210204230340-5267aaa9c572/go.mod h1:Jd94uBfq6b9i+kDYQTp6mdnh9fg+WHNcG3P5LwXonGg=
+github.com/erikh/tftest v0.0.0-20210209001423-da33e4a905df h1:sOpMMrPFPkRE4nhgGLU/IR+FY+rh9Rr0rHveLKhf9pE=
+github.com/erikh/tftest v0.0.0-20210209001423-da33e4a905df/go.mod h1:vx3mrhx5Lwgi9I28A5NrKYN11h2y2gk0OT1xiKR2lhE=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.10.0 h1:s36xzo75JdqLaaWoiEHk767eHiwo0598uUxyfiPkDsg=

--- a/main_test.go
+++ b/main_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/erikh/tftest"
 	"github.com/someara/terraform-provider-zerotier/pkg/zerotier-client"
 )
 
@@ -45,4 +46,10 @@ func TestMain(m *testing.M) {
 	}
 
 	os.Exit(m.Run())
+}
+
+func getTFTest(t *testing.T) *tftest.Harness {
+	tf := tftest.New(t)
+	tf.HandleSignals(true)
+	return tf
 }

--- a/ping_test.go
+++ b/ping_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/stdcopy"
-	"github.com/erikh/tftest"
 )
 
 var (
@@ -114,7 +113,7 @@ func execContainer(ctx context.Context, docker *client.Client, containerID strin
 }
 
 func TestDockerPing(t *testing.T) {
-	tf := tftest.New(t)
+	tf := getTFTest(t)
 	tf.Apply("testdata/plans/docker-integration.tf")
 
 	var aliceCID, bobCID string

--- a/provision_test.go
+++ b/provision_test.go
@@ -26,7 +26,7 @@ type identity struct {
 	privkey string
 }
 
-func extractIdentities(tf tftest.Harness) map[string]identity {
+func extractIdentities(tf *tftest.Harness) map[string]identity {
 	resources := a(tf.State()["resources"])
 
 	ids := map[string]identity{}
@@ -46,7 +46,7 @@ func extractIdentities(tf tftest.Harness) map[string]identity {
 }
 
 func TestIdentity(t *testing.T) {
-	tf := tftest.New(t)
+	tf := getTFTest(t)
 	tf.Apply("testdata/plans/basic-identity.tf")
 
 	ids := extractIdentities(tf)
@@ -71,6 +71,6 @@ func TestIdentity(t *testing.T) {
 }
 
 func TestBasicNetworkSetup(t *testing.T) {
-	tf := tftest.New(t)
+	tf := getTFTest(t)
 	tf.Apply("testdata/plans/basic-network.tf")
 }


### PR DESCRIPTION
this would previously orphan containers which could break future runs.

Signed-off-by: Erik Hollensbe <github@hollensbe.org>
