### PR TITLE
Rewrite structured stanzas to be resources instead of maps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
-TEST?=$$(go list ./... | grep -v 'vendor')
 HOSTNAME=zerotier.com
 NAMESPACE=dev
 NAME=zerotier

--- a/pkg/zerotier/provider.go
+++ b/pkg/zerotier/provider.go
@@ -15,12 +15,12 @@ const HostURL = "https://my.zerotier.com/api"
 func Provider() *schema.Provider {
 	return &schema.Provider{
 		Schema: map[string]*schema.Schema{
-			"zerotier_controller_url": &schema.Schema{
+			"zerotier_controller_url": {
 				Type:        schema.TypeString,
 				Required:    true,
 				DefaultFunc: schema.EnvDefaultFunc("ZEROTIER_CONTROLLER_URL", HostURL),
 			},
-			"zerotier_controller_token": &schema.Schema{
+			"zerotier_controller_token": {
 				Type:        schema.TypeString,
 				Required:    true,
 				DefaultFunc: schema.EnvDefaultFunc("ZEROTIER_CONTROLLER_TOKEN", nil),

--- a/pkg/zerotier/resource_network.go
+++ b/pkg/zerotier/resource_network.go
@@ -42,24 +42,31 @@ func resourceNetwork() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"via": {
 							Type:     schema.TypeString,
-							Optional: true,
+							Required: true,
 						},
 						"target": {
 							Type:     schema.TypeString,
-							Optional: true,
+							Required: true,
 						},
 					},
 				},
 			},
 			"assignment_pool": {
-				Type: schema.TypeList,
-				Elem: &schema.Schema{
-					Type: schema.TypeMap,
-					Elem: &schema.Schema{
-						Type: schema.TypeString,
+				Type:     schema.TypeSet,
+				Optional: true,
+				ForceNew: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"start": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"end": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
 					},
 				},
-				Optional: true,
 			},
 		},
 	}
@@ -110,15 +117,11 @@ func mkIPRangeFromCIDR(cidr interface{}) (ztcentral.IPRange, error) {
 }
 
 func mkIPRange(ranges interface{}) ([]ztcentral.IPRange, error) {
-	if ranges == nil {
-		return []ztcentral.IPRange{}, nil
-	}
-
 	ret := []ztcentral.IPRange{}
 
-	for _, r := range ranges.([]interface{}) {
-		var start, end string
+	for _, r := range ranges.(*schema.Set).List() {
 		m := r.(map[string]interface{})
+		var start, end string
 		if s, ok := m["start"]; ok {
 			start = s.(string)
 		} else {

--- a/testdata/plans/docker-integration.tf
+++ b/testdata/plans/docker-integration.tf
@@ -80,10 +80,10 @@ resource "zerotier_network" "docker_network" {
     end   = "10.0.1.253"
   }]
 
-  routes = [{
+  route {
     target = var.ipv4_cidr
     via    = "10.0.0.1"
-  }]
+  }
 }
 
 resource "zerotier_identity" "alice" {}

--- a/testdata/plans/docker-integration.tf
+++ b/testdata/plans/docker-integration.tf
@@ -75,10 +75,11 @@ variable "ipv4_cidr" {
 
 resource "zerotier_network" "docker_network" {
   name = "docker"
-  assignment_pool = [{
+
+  assignment_pool {
     start = "10.0.1.2"
     end   = "10.0.1.253"
-  }]
+  }
 
   route {
     target = var.ipv4_cidr


### PR DESCRIPTION
This allows our HCL to look like:

```hcl

resource {
  foo {
    name = "baz"
  }

  foo {
    name = "bar"
  }
}
```

What we were doing previously was:

```hcl
resource {
  foos = [
    {
      name = "bar"
    },
    {
      name = "baz"
    }
  ]
}
```

The first patch is for `route`, and more are coming.

This took some time to figure out, but is more ergonomic in the HCL
world. Other resources are coming, now that I know how to do this work.

Signed-off-by: Erik Hollensbe <github@hollensbe.org>
