### PR TITLE
More resources with tests

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	"github.com/erikh/tftest"
-	"github.com/someara/terraform-provider-zerotier/pkg/zerotier"
+	"github.com/zerotier/go-ztcentral"
 )
 
 var (
@@ -41,8 +41,8 @@ func TestMain(m *testing.M) {
 	os.Setenv("ZEROTIER_CONTROLLER_TOKEN", controllerToken)
 
 	if controllerURL == "" {
-		controllerURL = zerotier.HostURL
-		os.Setenv("ZEROTIER_CONTROLLER_URL", zerotier.HostURL)
+		controllerURL = ztcentral.BaseURLV1
+		os.Setenv("ZEROTIER_CONTROLLER_URL", controllerURL)
 	}
 
 	os.Exit(m.Run())

--- a/pkg/zerotier/converters.go
+++ b/pkg/zerotier/converters.go
@@ -132,3 +132,51 @@ func mktfRanges(ranges []ztcentral.IPRange) interface{} {
 
 	return ret
 }
+
+func mktfipv6assign(ipv6 ztcentral.IPV6AssignMode) map[string]interface{} {
+	return map[string]interface{}{
+		"zerotier": ipv6.ZeroTier,
+		"sixplane": ipv6.ZT6Plane,
+		"rfc4193":  ipv6.RFC4193,
+	}
+}
+
+func mktfipv4assign(ipv4 ztcentral.IPV4AssignMode) map[string]interface{} {
+	return map[string]interface{}{
+		"zerotier": ipv4.ZeroTier,
+	}
+}
+
+func mkipv4assign(assignments interface{}) ztcentral.IPV4AssignMode {
+	m := assignments.(map[string]interface{})
+	var zt bool
+	if z, ok := m["zerotier"]; ok {
+		zt = z.(bool)
+	} else {
+		zt = true // default
+	}
+
+	return ztcentral.IPV4AssignMode{ZeroTier: zt}
+}
+
+func mkipv6assign(assignments interface{}) ztcentral.IPV6AssignMode {
+	m := assignments.(map[string]interface{})
+	var zt bool
+	if z, ok := m["zerotier"]; ok {
+		zt = z.(bool)
+	} else {
+		zt = true // default
+	}
+
+	var sixPlane bool
+	if s, ok := m["sixplane"]; ok {
+		sixPlane = s.(bool)
+	}
+
+	var rfc4193 bool
+	if r, ok := m["rfc4193"]; ok {
+		rfc4193 = r.(bool)
+	}
+
+	return ztcentral.IPV6AssignMode{ZeroTier: zt, ZT6Plane: sixPlane, RFC4193: rfc4193}
+}

--- a/pkg/zerotier/converters.go
+++ b/pkg/zerotier/converters.go
@@ -1,0 +1,134 @@
+package zerotier
+
+import (
+	"errors"
+	"math/big"
+	"net"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/zerotier/go-ztcentral"
+)
+
+// FIXME keep this. we'll use it later.
+func mkIPRangeFromCIDR(cidr interface{}) (ztcentral.IPRange, error) {
+	iprange := ztcentral.IPRange{}
+
+	first, nw, err := net.ParseCIDR(cidr.(string))
+	if err != nil {
+		return iprange, err
+	}
+
+	var last net.IP
+
+	prefixLen, bits := nw.Mask.Size()
+
+	if prefixLen == bits {
+		last = first
+	} else {
+		val := big.NewInt(0)
+		val.SetBytes(first)
+		lastVal := big.NewInt(1)
+		lastVal.Lsh(lastVal, uint(bits-prefixLen))
+		lastVal.Sub(lastVal, big.NewInt(1))
+		lastVal.Or(lastVal, val)
+
+		last = net.IP(make([]byte, len(first)))
+		b := lastVal.Bytes()
+		for i := 1; i <= len(b); i++ {
+			last[len(last)-i] = b[len(b)-i]
+		}
+
+		first = net.IP(make([]byte, len(first)))
+		b = val.Bytes()
+		for i := 1; i <= len(b); i++ {
+			first[len(first)-i] = b[len(b)-i]
+		}
+	}
+
+	iprange = ztcentral.IPRange{
+		Start: first.String(),
+		End:   last.String(),
+	}
+
+	return iprange, nil
+}
+
+func mkIPRange(ranges interface{}) ([]ztcentral.IPRange, error) {
+	ret := []ztcentral.IPRange{}
+
+	for _, r := range ranges.(*schema.Set).List() {
+		m := r.(map[string]interface{})
+		var start, end string
+		if s, ok := m["start"]; ok {
+			start = s.(string)
+		} else {
+			return ret, errors.New("start does not exist")
+		}
+
+		if e, ok := m["end"]; ok {
+			end = e.(string)
+		} else {
+			return ret, errors.New("end does not exist")
+		}
+
+		ret = append(ret, ztcentral.IPRange{
+			Start: start,
+			End:   end,
+		})
+	}
+
+	return ret, nil
+}
+
+func mkRoutes(routes interface{}) ([]ztcentral.Route, error) {
+	ret := []ztcentral.Route{}
+
+	for _, r := range routes.(*schema.Set).List() {
+		m := r.(map[string]interface{})
+		var target, via string
+		if t, ok := m["target"]; ok {
+			target = t.(string)
+		} else {
+			return ret, errors.New("target does not exist")
+		}
+
+		if v, ok := m["via"]; ok {
+			via = v.(string)
+		} else {
+			return ret, errors.New("target does not exist")
+		}
+
+		ret = append(ret, ztcentral.Route{
+			Target: target,
+			Via:    via,
+		})
+	}
+
+	return ret, nil
+}
+
+func mktfRoutes(routes []ztcentral.Route) interface{} {
+	ret := []map[string]interface{}{}
+
+	for _, route := range routes {
+		ret = append(ret, map[string]interface{}{
+			"target": route.Target,
+			"via":    route.Via,
+		})
+	}
+
+	return ret
+}
+
+func mktfRanges(ranges []ztcentral.IPRange) interface{} {
+	ret := []map[string]interface{}{}
+
+	for _, r := range ranges {
+		ret = append(ret, map[string]interface{}{
+			"start": r.Start,
+			"end":   r.End,
+		})
+	}
+
+	return ret
+}

--- a/pkg/zerotier/provider.go
+++ b/pkg/zerotier/provider.go
@@ -8,9 +8,6 @@ import (
 	"github.com/zerotier/go-ztcentral"
 )
 
-// HostURL is the URL of the standard ZeroTier client API endpoint.
-const HostURL = "https://my.zerotier.com/api"
-
 // Provider -
 func Provider() *schema.Provider {
 	return &schema.Provider{
@@ -18,7 +15,7 @@ func Provider() *schema.Provider {
 			"zerotier_controller_url": {
 				Type:        schema.TypeString,
 				Required:    true,
-				DefaultFunc: schema.EnvDefaultFunc("ZEROTIER_CONTROLLER_URL", HostURL),
+				DefaultFunc: schema.EnvDefaultFunc("ZEROTIER_CONTROLLER_URL", ztcentral.BaseURLV1),
 			},
 			"zerotier_controller_token": {
 				Type:        schema.TypeString,
@@ -39,12 +36,13 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 	ztControllerURL := d.Get("zerotier_controller_url").(string)
 	ztControllerToken := d.Get("zerotier_controller_token").(string)
 
-	// Warning or errors can be collected in a slice type
-	var diags diag.Diagnostics
-
-	if (ztControllerURL != "") && (ztControllerToken != "") {
+	if ztControllerToken != "" {
 		c := ztcentral.NewClient(ztControllerToken)
-		return c, diags
+		if ztControllerURL != "" {
+			c.BaseURL = ztControllerURL
+		}
+
+		return c, nil
 	}
 
 	return nil, diag.Errorf("zerotier_controller_token must be specified, or ZEROTIER_CONTROLLER_TOKEN must be specified in environment")

--- a/pkg/zerotier/resource_network.go
+++ b/pkg/zerotier/resource_network.go
@@ -2,10 +2,7 @@ package zerotier
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"math/big"
-	"net"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -70,130 +67,6 @@ func resourceNetwork() *schema.Resource {
 			},
 		},
 	}
-}
-
-// FIXME keep this. we'll use it later.
-func mkIPRangeFromCIDR(cidr interface{}) (ztcentral.IPRange, error) {
-	iprange := ztcentral.IPRange{}
-
-	first, nw, err := net.ParseCIDR(cidr.(string))
-	if err != nil {
-		return iprange, err
-	}
-
-	var last net.IP
-
-	prefixLen, bits := nw.Mask.Size()
-
-	if prefixLen == bits {
-		last = first
-	} else {
-		val := big.NewInt(0)
-		val.SetBytes(first)
-		lastVal := big.NewInt(1)
-		lastVal.Lsh(lastVal, uint(bits-prefixLen))
-		lastVal.Sub(lastVal, big.NewInt(1))
-		lastVal.Or(lastVal, val)
-
-		last = net.IP(make([]byte, len(first)))
-		b := lastVal.Bytes()
-		for i := 1; i <= len(b); i++ {
-			last[len(last)-i] = b[len(b)-i]
-		}
-
-		first = net.IP(make([]byte, len(first)))
-		b = val.Bytes()
-		for i := 1; i <= len(b); i++ {
-			first[len(first)-i] = b[len(b)-i]
-		}
-	}
-
-	iprange = ztcentral.IPRange{
-		Start: first.String(),
-		End:   last.String(),
-	}
-
-	return iprange, nil
-}
-
-func mkIPRange(ranges interface{}) ([]ztcentral.IPRange, error) {
-	ret := []ztcentral.IPRange{}
-
-	for _, r := range ranges.(*schema.Set).List() {
-		m := r.(map[string]interface{})
-		var start, end string
-		if s, ok := m["start"]; ok {
-			start = s.(string)
-		} else {
-			return ret, errors.New("start does not exist")
-		}
-
-		if e, ok := m["end"]; ok {
-			end = e.(string)
-		} else {
-			return ret, errors.New("end does not exist")
-		}
-
-		ret = append(ret, ztcentral.IPRange{
-			Start: start,
-			End:   end,
-		})
-	}
-
-	return ret, nil
-}
-
-func mkRoutes(routes interface{}) ([]ztcentral.Route, error) {
-	ret := []ztcentral.Route{}
-
-	for _, r := range routes.(*schema.Set).List() {
-		m := r.(map[string]interface{})
-		var target, via string
-		if t, ok := m["target"]; ok {
-			target = t.(string)
-		} else {
-			return ret, errors.New("target does not exist")
-		}
-
-		if v, ok := m["via"]; ok {
-			via = v.(string)
-		} else {
-			return ret, errors.New("target does not exist")
-		}
-
-		ret = append(ret, ztcentral.Route{
-			Target: target,
-			Via:    via,
-		})
-	}
-
-	return ret, nil
-}
-
-func mktfRoutes(routes []ztcentral.Route) interface{} {
-	ret := []map[string]interface{}{}
-
-	for _, route := range routes {
-		ret = append(ret, map[string]interface{}{
-			"target": route.Target,
-			"via":    route.Via,
-		})
-	}
-
-	return ret
-}
-
-func mktfRanges(ranges []ztcentral.IPRange) interface{} {
-	ret := []map[string]interface{}{}
-
-	for _, r := range ranges {
-		ret = append(ret, map[string]interface{}{
-			"start": r.Start,
-			"end":   r.End,
-		})
-	}
-
-	return ret
 }
 
 func resourceNetworkCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {

--- a/pkg/zerotier/resource_network.go
+++ b/pkg/zerotier/resource_network.go
@@ -112,9 +112,9 @@ func resourceNetworkCreate(ctx context.Context, d *schema.ResourceData, m interf
 		IPV4AssignMode:   ztcentral.IPV4AssignMode{ZeroTier: true},
 		IPV6AssignMode:   ztcentral.IPV6AssignMode{ZeroTier: true},
 		EnableBroadcast:  d.Get("enable_broadcast").(bool),
-		// MTU:              d.Get("mtu").(int),
-		MulticastLimit: d.Get("multicast_limit").(int),
-		Private:        d.Get("private").(bool),
+		MTU:              d.Get("mtu").(int),
+		MulticastLimit:   d.Get("multicast_limit").(int),
+		Private:          d.Get("private").(bool),
 	})
 
 	if err != nil {
@@ -150,9 +150,8 @@ func resourceNetworkRead(ctx context.Context, d *schema.ResourceData, m interfac
 	}
 
 	d.Set("name", ztNetwork.Config.Name)
-	// FIXME needs patch to ztcentral
-	// d.Set("last_modified", ztNetwork.Config.LastModified)
-	// d.Set("mtu", ztNetwork.Config.MTU)
+	d.Set("last_modified", ztNetwork.Config.LastModified)
+	d.Set("mtu", ztNetwork.Config.MTU)
 	d.Set("creation_time", ztNetwork.Config.CreationTime)
 	d.Set("description", ztNetwork.Description)
 	d.Set("route", mktfRoutes(ztNetwork.Config.Routes))
@@ -208,8 +207,7 @@ func resourceNetworkUpdate(ctx context.Context, d *schema.ResourceData, m interf
 			})
 			return diags
 		}
-		// FIXME needs patch to ztcentral
-		// d.Set("last_modified", ztNetwork.Config.LastModified)
+		d.Set("last_modified", ztNetwork.Config.LastModified)
 		d.Set("tf_last_updated", time.Now().Unix())
 	}
 

--- a/provision_test.go
+++ b/provision_test.go
@@ -81,15 +81,17 @@ func TestBasicNetworkSetup(t *testing.T) {
 		switch m["type"] {
 		case "zerotier_network":
 			switch m["name"] {
-			case "no_broadcast":
-				b, ok := attrs["enable_broadcast"].(bool)
-				if !ok {
-					t.Fatal("enable_broadcast was not set")
-				}
-
-				if b {
-					t.Fatal("enable_broadcast was improperly set")
-				}
+			// FIXME: missing/failing support for these test cases in the Client API
+			//
+			// What should happen when the API is updated so that these items can
+			// be modified, is that these tests can be uncommented and that they
+			// will automagically pass, because all the plumbing is already done
+			// for you, presuming nothing moves, etc.
+			//
+			// PLEASE NOTE that the case statements /themselves/ must be left
+			// available so they are exhausted in before the default statement, which
+			// will fail the test for unknown networks. This is a safeguard to keep
+			// extraneous stuff from landing in the test plan.
 			case "mtu":
 				// i, ok := attrs["mtu"].(float64)
 				// if !ok {
@@ -117,6 +119,32 @@ func TestBasicNetworkSetup(t *testing.T) {
 				// if s != "My description is changed!" {
 				// 	t.Fatalf("description was improperly set")
 				// }
+			case "assign_off":
+				m, ok := attrs["assign_ipv4"]
+				if !ok {
+					t.Fatal("assign_ipv4 key was missing")
+				}
+
+				if b, ok := h(m)["zerotier"].(bool); !ok || b {
+					t.Fatal("assign_ipv4/zerotier was not set to false")
+				}
+
+				m, ok = attrs["assign_ipv6"]
+				if !ok {
+					t.Fatal("assign_ipv6 key was missing")
+				}
+
+				if b, ok := h(m)["zerotier"].(bool); !ok || b {
+					t.Fatal("assign_ipv6/zerotier was not set to false")
+				}
+
+				if b, ok := h(m)["sixplane"].(bool); !ok || !b {
+					t.Fatal("assign_ipv6/sixplane was not set to true")
+				}
+
+				if b, ok := h(m)["rfc4193"].(bool); !ok || !b {
+					t.Fatal("assign_ipv6/rfc4193 was not set to true")
+				}
 			case "private":
 				b, ok := attrs["private"].(bool)
 				if !ok {
@@ -125,6 +153,15 @@ func TestBasicNetworkSetup(t *testing.T) {
 
 				if !b {
 					t.Fatalf("private was improperly set")
+				}
+			case "no_broadcast":
+				b, ok := attrs["enable_broadcast"].(bool)
+				if !ok {
+					t.Fatal("enable_broadcast was not set")
+				}
+
+				if b {
+					t.Fatal("enable_broadcast was improperly set")
 				}
 			case "alice", "bobs_garage":
 				if f, ok := attrs["creation_time"].(float64); !ok || f == 0 {
@@ -143,12 +180,38 @@ func TestBasicNetworkSetup(t *testing.T) {
 					t.Fatal("private should be defaulted to false")
 				}
 
+				m, ok := attrs["assign_ipv4"]
+				if !ok {
+					t.Fatal("assign_ipv4 key was missing")
+				}
+
+				if b, ok := h(m)["zerotier"].(bool); !ok || !b {
+					t.Fatal("assign_ipv4/zerotier was not set to true")
+				}
+
+				m, ok = attrs["assign_ipv6"]
+				if !ok {
+					t.Fatal("assign_ipv6 key was missing")
+				}
+
+				if b, ok := h(m)["zerotier"].(bool); !ok || !b {
+					t.Fatal("assign_ipv6/zerotier was not set to true")
+				}
+
+				if b, ok := h(m)["sixplane"].(bool); !ok || b {
+					t.Fatal("assign_ipv6/sixplane was not set to false")
+				}
+
+				if b, ok := h(m)["rfc4193"].(bool); !ok || b {
+					t.Fatal("assign_ipv6/rfc4193 was not set to false")
+				}
+
 				// FIXME needs patch to ztcentral
 				// if f, ok := attrs["last_modified"].(float64); !ok || f == 0 {
 				// 	t.Fatal("last modified (on zerotier) for alice network was 0")
 				// }
 			default:
-				t.Fatalf("Unexpected network %q", m["name"])
+				t.Fatalf("Unexpected network %q in plan", m["name"])
 			}
 		}
 	}

--- a/provision_test.go
+++ b/provision_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 // these are deliberately named to keep the code small. they do not add
-// anything else. Hopefully we won't need this soon.
+// anything else.
 func h(m interface{}) map[string]interface{} {
 	return m.(map[string]interface{})
 }
@@ -73,4 +73,83 @@ func TestIdentity(t *testing.T) {
 func TestBasicNetworkSetup(t *testing.T) {
 	tf := getTFTest(t)
 	tf.Apply("testdata/plans/basic-network.tf")
+
+	for _, resource := range a(tf.State()["resources"]) {
+		m := h(resource)
+		attrs := h(h(a(m["instances"])[0])["attributes"])
+
+		switch m["type"] {
+		case "zerotier_network":
+			switch m["name"] {
+			case "no_broadcast":
+				b, ok := attrs["enable_broadcast"].(bool)
+				if !ok {
+					t.Fatal("enable_broadcast was not set")
+				}
+
+				if b {
+					t.Fatal("enable_broadcast was improperly set")
+				}
+			case "mtu":
+				// i, ok := attrs["mtu"].(float64)
+				// if !ok {
+				// 	t.Fatal("mtu was not set")
+				// }
+				//
+				// if i != 1500 {
+				// 	t.Fatalf("mtu was improperly set: %f", i)
+				// }
+			case "multicast_limit":
+				// i, ok := attrs["multicast_limit"].(float64)
+				// if !ok {
+				// 	t.Fatal("multicast_limit was not set")
+				// }
+				//
+				// if i != 50 {
+				// 	t.Fatalf("multicast_limit was improperly set: %f", i)
+				// }
+			case "description":
+				// s, ok := attrs["description"].(string)
+				// if !ok {
+				// 	t.Fatal("description was not set")
+				// }
+				//
+				// if s != "My description is changed!" {
+				// 	t.Fatalf("description was improperly set")
+				// }
+			case "private":
+				b, ok := attrs["private"].(bool)
+				if !ok {
+					t.Fatal("private was not set")
+				}
+
+				if !b {
+					t.Fatalf("private was improperly set")
+				}
+			case "alice", "bobs_garage":
+				if f, ok := attrs["creation_time"].(float64); !ok || f == 0 {
+					t.Fatal("creation time for alice network was 0")
+				}
+
+				if f, ok := attrs["tf_last_updated"].(float64); !ok || f == 0 {
+					t.Fatal("tf_last_updated (in terraform) for alice network was 0")
+				}
+
+				if b, ok := attrs["enable_broadcast"].(bool); !ok || !b {
+					t.Fatal("enable_broadcast should be defaulted to true")
+				}
+
+				if b, ok := attrs["private"].(bool); !ok || b {
+					t.Fatal("private should be defaulted to false")
+				}
+
+				// FIXME needs patch to ztcentral
+				// if f, ok := attrs["last_modified"].(float64); !ok || f == 0 {
+				// 	t.Fatal("last modified (on zerotier) for alice network was 0")
+				// }
+			default:
+				t.Fatalf("Unexpected network %q", m["name"])
+			}
+		}
+	}
 }

--- a/testdata/plans/basic-network.tf
+++ b/testdata/plans/basic-network.tf
@@ -21,8 +21,6 @@ variable "networks" {
 resource "zerotier_network" "alice" {
   for_each = var.networks
   name     = each.key
-  #  assignment_pool { cidr = each.value.ipv4_cidr }
-  #  route { target = each.value.ipv4_cidr }
 }
 
 resource "zerotier_identity" "alice" {}
@@ -35,19 +33,34 @@ resource "zerotier_member" "alice" {
 }
 
 
-#
-# Bob
-#
-
 resource "zerotier_network" "bobs_garage" {
   name        = "bobs_garage"
   description = "so say we bob"
-  //  rules_source = "accept;"
-  //  ip_assignment_pools {
-  //      ip_range_start = "192.168.1.1"
-  //      ip_range_end = "192.168.1.254"
-  //  }
-  //  routes { target = "192.168.1.0/24" }
+}
+
+resource "zerotier_network" "description" {
+  name        = "description"
+  description = "My description is changed!"
+}
+
+resource "zerotier_network" "no_broadcast" {
+  name             = "no_broadcast"
+  enable_broadcast = false
+}
+
+resource "zerotier_network" "mtu" {
+  name = "mtu"
+  mtu  = 1500
+}
+
+resource "zerotier_network" "multicast_limit" {
+  name            = "multicast_limit"
+  multicast_limit = 50
+}
+
+resource "zerotier_network" "private" {
+  name    = "private"
+  private = true
 }
 
 resource "zerotier_identity" "bob" {}
@@ -57,10 +70,3 @@ resource "zerotier_member" "bob" {
   node_id    = zerotier_identity.bob.id
   network_id = zerotier_network.bobs_garage.id
 }
-
-#resource "zerotier_member" "sean" {
-#  name           = "sean"
-#  node_id        = "eff05def90"
-#  network_id     = zerotier_network.bob.id
-#  ip_assignments = ["192.168.1.42", "192.168.1.69"]
-#}

--- a/testdata/plans/basic-network.tf
+++ b/testdata/plans/basic-network.tf
@@ -38,6 +38,19 @@ resource "zerotier_network" "bobs_garage" {
   description = "so say we bob"
 }
 
+resource "zerotier_network" "assign_off" {
+  name = "assign_off"
+  assign_ipv4 = {
+    zerotier = false
+  }
+
+  assign_ipv6 = {
+    zerotier = false
+    sixplane = true
+    rfc4193  = true
+  }
+}
+
 resource "zerotier_network" "description" {
   name        = "description"
   description = "My description is changed!"


### PR DESCRIPTION
This is several properties I added that include tests, read
testdata/plans/basic-network.tf for more information on how to use them, in
lieu of documentation.

My next patch to this behavior will be a bit more ambitious, as well as address
the update state management (which is not handled in this patch, only
create/read is). It needs to manage all this stuff in a bag, instead of loose leaf
like it is now.

Signed-off-by: Erik Hollensbe <github@hollensbe.org>
