### PR TITLE
Schemawrap, a large refactor of the network side

### DIFF
--- a/pkg/zerotier/resource_network.go
+++ b/pkg/zerotier/resource_network.go
@@ -14,102 +14,9 @@ func resourceNetwork() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceNetworkCreate,
 		ReadContext:   resourceNetworkRead,
-		UpdateContext: resourceNetworkUpdate,
+		UpdateContext: resourceNetworkRead, // schemawrap makes these equivalent
 		DeleteContext: resourceNetworkDelete,
-		Schema: map[string]*schema.Schema{
-			"creation_time": {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
-			"tf_last_updated": {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
-			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			"description": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Default:  "Managed by Terraform",
-			},
-			"enable_broadcast": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  true,
-			},
-			"mtu": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				Default:  2800,
-			},
-			"multicast_limit": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				Default:  32,
-			},
-			"private": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-			},
-			"route": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				ForceNew: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"via": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						"target": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-					},
-				},
-			},
-			"assign_ipv4": {
-				Type:     schema.TypeMap,
-				Optional: true,
-				ForceNew: true,
-				Elem: &schema.Schema{
-					Type:     schema.TypeBool,
-					Optional: true,
-					ForceNew: true,
-					Default:  true,
-				},
-			},
-			"assign_ipv6": {
-				Type:     schema.TypeMap,
-				Optional: true,
-				ForceNew: true,
-				Elem: &schema.Schema{
-					Type:     schema.TypeBool,
-					Optional: true,
-					ForceNew: true,
-				},
-			},
-			"assignment_pool": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				ForceNew: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"start": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						"end": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-					},
-				},
-			},
-		},
+		Schema:        ZTNetwork.TerraformSchema(),
 	}
 }
 
@@ -119,44 +26,26 @@ const (
 )
 
 func resourceNetworkCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	if err := ZTNetwork.CollectFromTerraform(d); err != nil {
+		return err
+	}
+
 	c := m.(*ztcentral.Client)
-	var diags diag.Diagnostics
+	netConfig := ZTNetwork.Yield().(*ztcentral.NetworkConfig)
 
-	routes, err := mkRoutes(d.Get("route"))
+	n, err := c.NewNetwork(ctx, netConfig.Name, netConfig)
 	if err != nil {
-		return diag.FromErr(err)
-	}
-
-	ipranges, err := mkIPRange(d.Get("assignment_pool"))
-	if err != nil {
-		return diag.FromErr(err)
-	}
-
-	n, err := c.NewNetwork(ctx, d.Get("name").(string), &ztcentral.NetworkConfig{
-		IPAssignmentPool: ipranges,
-		Routes:           routes,
-		IPV4AssignMode:   mkipv4assign(d.Get("assign_ipv4")),
-		IPV6AssignMode:   mkipv6assign(d.Get("assign_ipv6")),
-		EnableBroadcast:  d.Get("enable_broadcast").(bool),
-		MTU:              d.Get("mtu").(int),
-		MulticastLimit:   d.Get("multicast_limit").(int),
-		Private:          d.Get("private").(bool),
-	})
-
-	if err != nil {
-		diags = append(diags, diag.Diagnostic{
+		return []diag.Diagnostic{{
 			Severity: diag.Error,
 			Summary:  "Unable to create ZeroTier Network",
 			Detail:   fmt.Sprintf("CreateNetwork returned error: %v", err),
-		})
-		return diags
+		}}
 	}
 
 	d.SetId(n.ID)
 	d.Set("tf_last_updated", time.Now().Unix())
 
-	resourceNetworkRead(ctx, d, m)
-	return diags
+	return resourceNetworkRead(ctx, d, m)
 }
 
 func resourceNetworkRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
@@ -165,7 +54,6 @@ func resourceNetworkRead(ctx context.Context, d *schema.ResourceData, m interfac
 
 	ztNetworkID := d.Id()
 	ztNetwork, err := c.GetNetwork(ctx, ztNetworkID)
-
 	if err != nil {
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
@@ -175,72 +63,7 @@ func resourceNetworkRead(ctx context.Context, d *schema.ResourceData, m interfac
 		return diags
 	}
 
-	d.Set("name", ztNetwork.Config.Name)
-	d.Set("last_modified", ztNetwork.Config.LastModified)
-	d.Set("mtu", ztNetwork.Config.MTU)
-	d.Set("creation_time", ztNetwork.Config.CreationTime)
-	d.Set("description", ztNetwork.Description)
-	d.Set("route", mktfRoutes(ztNetwork.Config.Routes))
-	d.Set("assignment_pool", mktfRanges(ztNetwork.Config.IPAssignmentPool))
-	d.Set("enable_broadcast", ztNetwork.Config.EnableBroadcast)
-	d.Set("multicast_limit", ztNetwork.Config.MulticastLimit)
-	d.Set("private", ztNetwork.Config.Private)
-	d.Set("assign_ipv4", mktfipv4assign(ztNetwork.Config.IPV4AssignMode))
-	d.Set("assign_ipv6", mktfipv6assign(ztNetwork.Config.IPV6AssignMode))
-
-	return diags
-}
-
-func resourceNetworkUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(*ztcentral.Client)
-	var diags diag.Diagnostics
-
-	ztNetworkID := d.Id()
-	ztNetwork, err := c.GetNetwork(ctx, ztNetworkID)
-	if err != nil {
-		return diag.FromErr(err)
-	}
-
-	var changed bool
-
-	if d.HasChange("description") {
-		changed = true
-		ztNetwork.Description = d.Get("description").(string)
-	}
-
-	if d.HasChange("route") {
-		changed = true
-		var err error
-		ztNetwork.Config.Routes, err = mkRoutes(d.Get("route"))
-		if err != nil {
-			diags = append(diags, diag.FromErr(err)...)
-		}
-	}
-
-	if d.HasChange("assignment_pool") {
-		changed = true
-		var err error
-		ztNetwork.Config.IPAssignmentPool, err = mkIPRange(d.Get("assignment_pool"))
-		if err != nil {
-			diags = append(diags, diag.FromErr(err)...)
-		}
-	}
-
-	if changed {
-		if _, err := c.UpdateNetwork(ctx, ztNetwork); err != nil {
-			diags = append(diags, diag.Diagnostic{
-				Severity: diag.Error,
-				Summary:  "Unable to update ZeroTier Network description",
-				Detail:   fmt.Sprintf("UpdateNetwork returned error: %v", err),
-			})
-			return diags
-		}
-		d.Set("last_modified", ztNetwork.Config.LastModified)
-		d.Set("tf_last_updated", time.Now().Unix())
-	}
-
-	// return diags
-	return resourceNetworkRead(ctx, d, m)
+	return ZTNetwork.CollectFromObject(d, &ztNetwork.Config)
 }
 
 func resourceNetworkDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {

--- a/pkg/zerotier/schemawrap.go
+++ b/pkg/zerotier/schemawrap.go
@@ -1,0 +1,127 @@
+package zerotier
+
+import (
+	"errors"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// ValidatedSchema is an internal schema for validating and managing lots of
+// schema parameters.
+type ValidatedSchema struct {
+	Schema map[string]*SchemaWrap
+	// Should be programmed to yield the type at Yield time.
+	YieldFunc func(ValidatedSchema) interface{}
+	// Should be programmed to populate the validated schema with Set calls.
+	CollectFunc func(ValidatedSchema, *schema.ResourceData, interface{}) diag.Diagnostics
+}
+
+// SchemaWrap wraps the terraform schema with validators and converters.
+type SchemaWrap struct {
+	Schema            *schema.Schema
+	ValidatorFunc     func(interface{}) diag.Diagnostics
+	FromTerraformFunc func(interface{}) (interface{}, diag.Diagnostics)
+	ToTerraformFunc   func(interface{}) interface{}
+	EqualFunc         func(interface{}, interface{}) bool
+	Value             interface{}
+}
+
+// TerraformSchema returns the unadulterated schema for use by terraform.
+func (vs ValidatedSchema) TerraformSchema() map[string]*schema.Schema {
+	res := map[string]*schema.Schema{}
+
+	for k, v := range vs.Schema {
+		res[k] = v.Schema
+	}
+
+	return res
+}
+
+// CollectFromTerraform collects all the properties listed in the validated schema, converts
+// & validates them, and makes this object available for further use. Failure
+// to call this method before others on the same transaction may result in
+// undefined behavior.
+func (vs ValidatedSchema) CollectFromTerraform(d *schema.ResourceData) diag.Diagnostics {
+	for key, sw := range vs.Schema {
+		var (
+			res interface{}
+			err diag.Diagnostics
+		)
+
+		if sw.FromTerraformFunc != nil {
+			if res, err = sw.FromTerraformFunc(d.Get(key)); err != nil {
+				return err
+			}
+		} else {
+			res = d.Get(key)
+		}
+
+		if sw.ValidatorFunc != nil {
+			if err := sw.ValidatorFunc(res); err != nil {
+				return err
+			}
+		}
+
+		sw.Value = res
+	}
+
+	return nil
+}
+
+// CollectFromObject is a pre-programmed call on the struct which accepts the
+// known object and sets all the values appropriately.
+func (vs ValidatedSchema) CollectFromObject(d *schema.ResourceData, i interface{}) diag.Diagnostics {
+	return vs.CollectFunc(vs, d, i)
+}
+
+// Get retrieves the set value inside the schema.
+func (vs ValidatedSchema) Get(key string) interface{} {
+	return vs.Schema[key].Value
+}
+
+// Set a value in terraform. This goes through our validation & conversion
+// first.
+func (vs ValidatedSchema) Set(d *schema.ResourceData, key string, value interface{}) diag.Diagnostics {
+	sw := vs.Schema[key]
+	if sw == nil {
+		return diag.FromErr(errors.New("invalid key, plugin error"))
+	}
+
+	if sw.ValidatorFunc != nil {
+		if err := sw.ValidatorFunc(value); err != nil {
+			return err
+		}
+	}
+
+	if sw.ToTerraformFunc != nil {
+		value = sw.ToTerraformFunc(value)
+		if err := d.Set(key, value); err != nil {
+			return diag.FromErr(err)
+		}
+	} else {
+		if err := d.Set(key, value); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	sw.Value = value
+
+	return nil
+}
+
+// RemoteChanged reports if our data source has changed.
+func (vs ValidatedSchema) RemoteChanged(d *schema.ResourceData) bool {
+	for key, sw := range vs.Schema {
+		if !sw.EqualFunc(sw.Value, d.Get(key)) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// Yield yields the type on request.
+func (vs ValidatedSchema) Yield() interface{} {
+	return vs.YieldFunc(vs)
+}

--- a/pkg/zerotier/validators.go
+++ b/pkg/zerotier/validators.go
@@ -1,0 +1,16 @@
+package zerotier
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+)
+
+func strNonEmpty(i interface{}) diag.Diagnostics {
+	if strings.TrimSpace(i.(string)) == "" {
+		return diag.FromErr(errors.New("value is an empty string"))
+	}
+
+	return nil
+}

--- a/pkg/zerotier/ztnetwork.go
+++ b/pkg/zerotier/ztnetwork.go
@@ -1,0 +1,173 @@
+package zerotier
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/zerotier/go-ztcentral"
+)
+
+func ztNetworkYield(vs ValidatedSchema) interface{} {
+	return &ztcentral.NetworkConfig{
+		Name:             vs.Get("name").(string),
+		IPAssignmentPool: vs.Get("assignment_pool").([]ztcentral.IPRange),
+		Routes:           vs.Get("route").([]ztcentral.Route),
+		IPV4AssignMode:   vs.Get("assign_ipv4").(ztcentral.IPV4AssignMode),
+		IPV6AssignMode:   vs.Get("assign_ipv6").(ztcentral.IPV6AssignMode),
+		EnableBroadcast:  vs.Get("enable_broadcast").(bool),
+		MTU:              vs.Get("mtu").(int),
+		MulticastLimit:   vs.Get("multicast_limit").(int),
+		Private:          vs.Get("private").(bool),
+	}
+}
+
+func ztNetworkCollect(vs ValidatedSchema, d *schema.ResourceData, i interface{}) diag.Diagnostics {
+	ztNetwork := i.(*ztcentral.NetworkConfig)
+
+	var diags diag.Diagnostics
+
+	diags = append(diags, vs.Set(d, "name", ztNetwork.Name)...)
+	diags = append(diags, vs.Set(d, "mtu", ztNetwork.MTU)...)
+	diags = append(diags, vs.Set(d, "creation_time", ztNetwork.CreationTime)...)
+	diags = append(diags, vs.Set(d, "route", ztNetwork.Routes)...)
+	diags = append(diags, vs.Set(d, "assignment_pool", ztNetwork.IPAssignmentPool)...)
+	diags = append(diags, vs.Set(d, "enable_broadcast", ztNetwork.EnableBroadcast)...)
+	diags = append(diags, vs.Set(d, "multicast_limit", ztNetwork.MulticastLimit)...)
+	diags = append(diags, vs.Set(d, "private", ztNetwork.Private)...)
+	diags = append(diags, vs.Set(d, "assign_ipv4", ztNetwork.IPV4AssignMode)...)
+	diags = append(diags, vs.Set(d, "assign_ipv6", ztNetwork.IPV6AssignMode)...)
+
+	return diags
+}
+
+// ZTNetwork is our internal validated schema. See schemawrap.go.
+var ZTNetwork = ValidatedSchema{
+	YieldFunc:   ztNetworkYield,
+	CollectFunc: ztNetworkCollect,
+	Schema: map[string]*SchemaWrap{
+		"creation_time": {
+			Schema: &schema.Schema{
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+		"tf_last_updated": {
+			Schema: &schema.Schema{
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+		"name": {
+			Schema: &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			ValidatorFunc: strNonEmpty,
+		},
+		"description": { // FIXME this is currently not working
+			Schema: &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "Managed by Terraform",
+			},
+		},
+		"enable_broadcast": {
+			Schema: &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+		},
+		"mtu": {
+			Schema: &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  2800,
+			},
+		},
+		"multicast_limit": {
+			Schema: &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  32,
+			},
+		},
+		"private": {
+			Schema: &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+		},
+		"route": {
+			FromTerraformFunc: mkRoutes,
+			ToTerraformFunc:   mktfRoutes,
+			Schema: &schema.Schema{
+				Type:     schema.TypeSet,
+				Optional: true,
+				ForceNew: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"via": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"target": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+		},
+		"assign_ipv4": {
+			FromTerraformFunc: mkipv4assign,
+			ToTerraformFunc:   mktfipv4assign,
+			Schema: &schema.Schema{
+				Type:     schema.TypeMap,
+				Optional: true,
+				ForceNew: true,
+				Elem: &schema.Schema{
+					Type:     schema.TypeBool,
+					Optional: true,
+					ForceNew: true,
+					Default:  true,
+				},
+			},
+		},
+		"assign_ipv6": {
+			FromTerraformFunc: mkipv6assign,
+			ToTerraformFunc:   mktfipv6assign,
+			Schema: &schema.Schema{
+				Type:     schema.TypeMap,
+				Optional: true,
+				ForceNew: true,
+				Elem: &schema.Schema{
+					Type:     schema.TypeBool,
+					Optional: true,
+					ForceNew: true,
+				},
+			},
+		},
+		"assignment_pool": {
+			FromTerraformFunc: mkIPRange,
+			ToTerraformFunc:   mktfRanges,
+			Schema: &schema.Schema{
+				Type:     schema.TypeSet,
+				Optional: true,
+				ForceNew: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"start": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"end": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+		},
+	},
+}


### PR DESCRIPTION
This allows us to keep the synchronization code small and rely on struct
properties with hooks, similar in function to how terraform works
itself. However, we have added additional functionality for the
automatic conversion of types and a very basic validations and
conversions system that is largely write-through.

It uses global variables as a staging ground, but I think that's ok at
this point.

I also plan to do this to member after a break. Then will write update tests.

Signed-off-by: Erik Hollensbe <github@hollensbe.org>
