### PR TITLE
Support flow rules; make compatible with the latest API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/opencontainers/image-spec v1.0.1 // indirect
 	github.com/sirupsen/logrus v1.7.0 // indirect
 	github.com/zclconf/go-cty v1.7.1 // indirect
-	github.com/zerotier/go-ztcentral v0.2.0
+	github.com/zerotier/go-ztcentral v0.2.1-0.20210213070016-be6aaad4acde
 	github.com/zerotier/go-ztidentity v1.0.0
 	golang.org/x/net v0.0.0-20210119194325-5f4716e94777 // indirect
 	golang.org/x/text v0.3.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -347,6 +347,8 @@ github.com/zclconf/go-cty v1.7.1/go.mod h1:VDR4+I79ubFBGm1uJac1226K5yANQFHeauxPB
 github.com/zclconf/go-cty-debug v0.0.0-20191215020915-b22d67c1ba0b/go.mod h1:ZRKQfBXbGkpdV6QMzT3rU1kSTAnfu1dO8dPKjYprgj8=
 github.com/zerotier/go-ztcentral v0.2.0 h1:/kFGwrDZA2uMQZPNKXhZNidWrai3YydxXW03qd8k4tM=
 github.com/zerotier/go-ztcentral v0.2.0/go.mod h1:90weKZT7Rdq02tdJskc+XR8W93bMgL/9uMCq4Txz0Hk=
+github.com/zerotier/go-ztcentral v0.2.1-0.20210213070016-be6aaad4acde h1:RlNjDsKOiZO25gT2zYaUoxagUPtb7Jx7VPF5fpzW4Es=
+github.com/zerotier/go-ztcentral v0.2.1-0.20210213070016-be6aaad4acde/go.mod h1:90weKZT7Rdq02tdJskc+XR8W93bMgL/9uMCq4Txz0Hk=
 github.com/zerotier/go-ztidentity v1.0.0 h1:dgm1ChTxw1TXMrSJQ6VWK2RmHKVYqRd69h/Co/RG+xo=
 github.com/zerotier/go-ztidentity v1.0.0/go.mod h1:zcOy+qXl5A01QhR6dfqOTPiHFMBEjgPlPpDPAO+2jg4=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=

--- a/pkg/zerotier/schemawrap.go
+++ b/pkg/zerotier/schemawrap.go
@@ -42,6 +42,36 @@ type SchemaWrap struct {
 	Value interface{}
 }
 
+func (sw *SchemaWrap) Clone() *SchemaWrap {
+	val, err := sw.Schema.DefaultValue()
+	if err != nil {
+		panic(err)
+	}
+
+	return &SchemaWrap{
+		Value:             val,
+		Schema:            sw.Schema,
+		ValidatorFunc:     sw.ValidatorFunc,
+		FromTerraformFunc: sw.FromTerraformFunc,
+		ToTerraformFunc:   sw.ToTerraformFunc,
+		EqualFunc:         sw.EqualFunc,
+	}
+}
+
+func (vs ValidatedSchema) Clone() ValidatedSchema {
+	vs2 := ValidatedSchema{
+		Schema:      map[string]*SchemaWrap{},
+		YieldFunc:   vs.YieldFunc,
+		CollectFunc: vs.CollectFunc,
+	}
+
+	for key, sw := range vs.Schema {
+		vs2.Schema[key] = sw.Clone()
+	}
+
+	return vs2
+}
+
 // TerraformSchema returns the unadulterated schema for use by terraform.
 func (vs ValidatedSchema) TerraformSchema() map[string]*schema.Schema {
 	res := map[string]*schema.Schema{}

--- a/provision_test.go
+++ b/provision_test.go
@@ -21,8 +21,16 @@ func s(m interface{}) string {
 }
 
 func isBool(t *testing.T, i interface{}, val bool, name string) {
-	if b, ok := i.(bool); !ok || b != val {
+	b, ok := i.(bool)
+	if ok && b != val {
 		t.Fatalf("%q was not set to %v", name, val)
+	} else if !ok {
+		b2, ok := i.(*bool)
+		if ok && (b2 == nil || *b2 != val) {
+			t.Fatalf("%q was not set to %v", name, val)
+		} else if !ok {
+			t.Fatalf("%q was not set properly", name)
+		}
 	}
 }
 
@@ -167,6 +175,10 @@ func TestBasicNetworkSetup(t *testing.T) {
 				// if s != "My description is changed!" {
 				// 	t.Fatalf("description was improperly set")
 				// }
+			case "flow_rules":
+				if attrs["flow_rules"].(string) != "drop;" {
+					t.Fatal("flow_rules were not altered")
+				}
 			case "assign_off":
 				isBool(t, h(attrs["assign_ipv4"])["zerotier"], false, "assign_ipv4/zerotier")
 
@@ -211,6 +223,10 @@ func TestBasicNetworkSetup(t *testing.T) {
 
 				for name, val := range table {
 					isBool(t, h(m)[name], val, "assign_ipv6/"+name)
+				}
+
+				if attrs["flow_rules"].(string) != "accept;" {
+					t.Fatal("flow_rules were not accept by default:", attrs["flow_rules"])
 				}
 
 				// FIXME needs patch to ztcentral

--- a/testdata/plans/basic-network.tf
+++ b/testdata/plans/basic-network.tf
@@ -76,6 +76,11 @@ resource "zerotier_network" "private" {
   private = true
 }
 
+resource "zerotier_network" "flow_rules" {
+  name       = "flow_rules"
+  flow_rules = "drop;"
+}
+
 resource "zerotier_identity" "bob" {}
 
 resource "zerotier_member" "bob" {


### PR DESCRIPTION
This required a number of changes:

- SchemaWrap required a copy constructor, it was doing really dumb stuff
I'd rather not discuss :)
- Pointer-ize many fields and manage boolean pointers safely and
properly.

The rest is fairly wrapped around supporting flow rules.

Signed-off-by: Erik Hollensbe <github@hollensbe.org>
